### PR TITLE
Texture Atlas now requries the user to save before we allow them to atlas.

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -15,13 +15,13 @@ license = [
   "SPDX:GPL-3.0-or-later",
 ]
 
-[permissions]
-network = "For the auto updater to work, you need to allow network access."
-files = "Import/ Export files, saving atlas images, saving preferences."
-
 wheels = [
   "./wheels/lz4-4.4.3-cp311-cp311-macosx_11_0_arm64.whl",
   "./wheels/lz4-4.3.3-cp311-cp311-macosx_10_9_x86_64.whl",
   "./wheels/lz4-4.4.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
   "./wheels/lz4-4.4.3-cp311-cp311-win_amd64.whl"
 ]
+
+[permissions]
+network = "For the auto updater to work, you need to allow network access"
+files = "Import/Export files, saving atlas images, saving preferences"

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -15,6 +15,10 @@ license = [
   "SPDX:GPL-3.0-or-later",
 ]
 
+[permissions]
+network = "For the auto updater to work, you need to allow network access."
+files = "Import/ Export files, saving atlas images, saving preferences."
+
 wheels = [
   "./wheels/lz4-4.4.3-cp311-cp311-macosx_11_0_arm64.whl",
   "./wheels/lz4-4.3.3-cp311-cp311-macosx_10_9_x86_64.whl",

--- a/functions/atlas_materials.py
+++ b/functions/atlas_materials.py
@@ -137,6 +137,10 @@ class AvatarToolKit_OT_AtlasMaterials(Operator):
 
     @classmethod
     def poll(cls, context: Context) -> bool:
+        # Only allow operation if the file is saved and materials are selected.
+        if not bpy.data.filepath:
+            cls.poll_message_set(t("TextureAtlas.save_file_first"))
+            return False
         return context.scene.avatar_toolkit.texture_atlas_Has_Mat_List_Shown
     
     def execute(self, context: Context) -> set:
@@ -208,8 +212,14 @@ class AvatarToolKit_OT_AtlasMaterials(Operator):
                                         image_pixels[int(((k*w)+i)*4)+channel]
 
                     canvas.pixels[:] = canvas_pixels[:]
-                    canvas.save(filepath=os.path.join(os.path.dirname(bpy.data.filepath),
-                                                    new_image_name+".png"))
+                    
+                    try:
+                        save_dir = os.path.dirname(bpy.data.filepath)
+                        canvas.save(filepath=os.path.join(save_dir, new_image_name+".png"))
+                    except Exception as save_error:
+                        logger.error(f"Failed to save atlas texture: {str(save_error)}")
+                        self.report({'WARNING'}, f"Could not save texture to disk. Atlas will work in memory only.")
+                    
                     setattr(atlased_mat, type_name, canvas)
                     progress.step(f"Created {type_name} atlas")
 

--- a/functions/atlas_materials.py
+++ b/functions/atlas_materials.py
@@ -218,7 +218,7 @@ class AvatarToolKit_OT_AtlasMaterials(Operator):
                         canvas.save(filepath=os.path.join(save_dir, new_image_name+".png"))
                     except Exception as save_error:
                         logger.error(f"Failed to save atlas texture: {str(save_error)}")
-                        self.report({'WARNING'}, f"Could not save texture to disk. Atlas will work in memory only.")
+                        self.report({'WARNING'}, f"Could not save texture to disk, This may be due to a lack of permissions.")
                     
                     setattr(atlased_mat, type_name, canvas)
                     progress.step(f"Created {type_name} atlas")

--- a/resources/translations/en_US.json
+++ b/resources/translations/en_US.json
@@ -489,6 +489,10 @@
     "TextureAtlas.how_to_use_2": "2. Click 'Load Materials' to begin",
     "TextureAtlas.load_error": "Error loading materials. Check console for details.",
     "TextureAtlas.material_not_included": "Material is not included in atlas",
+    "TextureAtlas.save_file_first": "Please save your Blender file before creating a texture atlas",
+    "TextureAtlas.save_file_instructions": "Use File > Save As... or click the button below:",
+    "TextureAtlas.save_file_button": "Save Blender File",
+    "TextureAtlas.save_file_required": "Save File Required",
 
     "Settings.label": "Settings",
     "Settings.language": "Language",

--- a/resources/translations/ja_JP.json
+++ b/resources/translations/ja_JP.json
@@ -489,6 +489,10 @@
     "TextureAtlas.how_to_use_2": "2. 「マテリアルを読み込む」をクリックして開始",
     "TextureAtlas.load_error": "マテリアルの読み込みエラー。詳細はコンソールを確認してください。",
     "TextureAtlas.material_not_included": "マテリアルはアトラスに含まれていません",
+    "TextureAtlas.save_file_first": "テクスチャアトラスを作成する前に、Blenderファイルを保存してください",
+    "TextureAtlas.save_file_instructions": "ファイル > 名前を付けて保存... を使用するか、下のボタンをクリックしてください：",
+    "TextureAtlas.save_file_button": "Blenderファイルを保存",
+    "TextureAtlas.save_file_required": "ファイルの保存が必要です",
 
     "Settings.label": "設定",
     "Settings.language": "言語",

--- a/resources/translations/ko_KR.json
+++ b/resources/translations/ko_KR.json
@@ -489,6 +489,10 @@
     "TextureAtlas.how_to_use_2": "2. '재질 불러오기'를 클릭하여 시작",
     "TextureAtlas.load_error": "재질 로딩 오류. 자세한 내용은 콘솔을 확인하세요.",
     "TextureAtlas.material_not_included": "재질이 아틀라스에 포함되지 않았습니다",
+    "TextureAtlas.save_file_first": "텍스처 아틀라스를 만들기 전에 Blender 파일을 저장하세요",
+    "TextureAtlas.save_file_instructions": "파일 > 다른 이름으로 저장... 을 사용하거나 아래 버튼을 클릭하세요:",
+    "TextureAtlas.save_file_button": "Blender 파일 저장",
+    "TextureAtlas.save_file_required": "파일 저장 필요",
 
     "Settings.label": "설정",
     "Settings.language": "언어",

--- a/ui/atlas_materials_panel.py
+++ b/ui/atlas_materials_panel.py
@@ -229,6 +229,16 @@ class AvatarToolKit_PT_TextureAtlasPanel(Panel):
             info_col.label(text=t("TextureAtlas.description_1"), icon='INFO')
             info_col.label(text=t("TextureAtlas.description_2"))
             
+            if not bpy.data.filepath:
+                warning_box = layout.box()
+                warning_col = warning_box.column()
+                warning_col.scale_y = 0.9
+                warning_col.alert = True
+                warning_col.label(text=t("TextureAtlas.save_file_first"), icon='ERROR')
+                warning_col.label(text=t("TextureAtlas.save_file_instructions"))
+                warning_col.operator("wm.save_as_mainfile", text=t("TextureAtlas.save_file_button"), icon='FILE_TICK')
+                layout.separator(factor=0.5)
+            
             layout.separator(factor=0.5)
             box = layout.box()
             row = box.row(align=True)

--- a/ui/custom_avatar_panel.py
+++ b/ui/custom_avatar_panel.py
@@ -2,6 +2,8 @@ import bpy
 from typing import Set, List, Tuple, Any
 from bpy.types import Panel, Context, UILayout, Operator, Event, WindowManager
 from .main_panel import AvatarToolKit_PT_AvatarToolkitPanel, CATEGORY_NAME
+from ..functions.custom_tools.mesh_attachment import AvatarToolkit_OT_AttachMesh
+from ..functions.custom_tools.armature_merging import AvatarToolkit_OT_MergeArmature
 from ..core.translations import t
 from ..core.common import (
     get_active_armature,


### PR DESCRIPTION
So this one i never discovered because I am on Linux however I was testing the plugin on my Windows machine and it turns out if the user does not save there blend file, the images will try to save in the blender install dictionary (Sometimes it will do temp depending on the machine it's a bit weird). 

Now I was thinking the best way to approach this however blender add-ons does not like you saving stuff to the temp folder and so on, so instead we now require the user to save before there can atlas, there are two messages telling the user this.

- In the UI there will be a red message telling the user there must save.
- The Atlas button will be greyed out unto the user saves, when you hover over the button it will tell the user in red text.

I have also added permissions to the blender manifest which is needed for Blender addons website and is best practice as we have an auto updater (This will be disabled if we ever submit to blender addons as blender should handle updates) and file permissions as we save files.

Edit: Also fixed Armature Merging and Mesh attaching, i swear I fixed this before.