### PR TITLE
Fix updater for Alpha 4 releases

### DIFF
--- a/core/updater.py
+++ b/core/updater.py
@@ -20,7 +20,7 @@ GITHUB_REPO = "teamneoneko/Avatar-Toolkit"
 # Define which version series this installation can update to
 # For example: ["0.1"] means only look for 0.1.x updates
 # ["0.2", "0.3"] would look for both 0.2.x and 0.3.x updates
-ALLOWED_VERSION_SERIES = ["0.3"]
+ALLOWED_VERSION_SERIES = ["0.3, 0.4"]
 
 is_checking_for_update: bool = False
 update_needed: bool = False


### PR DESCRIPTION
The tag never for updated for Alpha 4, but also the first release of alpha 4 tag was incorrect so this allows for Alpha 3 and 4 tags.